### PR TITLE
Fix do not show rankings in private #211

### DIFF
--- a/components/games/Bubble.vue
+++ b/components/games/Bubble.vue
@@ -274,7 +274,7 @@ export default {
       if (this.balls.length === 0) {
         // 終了処理(パーフェクトの場合＋3000)
         this.score += 3000;
-        this.message = this.$gameMessage.perfect + "（＋3000）";
+        this.message = this.$gameMessage.perfect + "(＋3000)";
         this.endOfGame();
         return
       }

--- a/components/games/Bubble.vue
+++ b/components/games/Bubble.vue
@@ -274,7 +274,7 @@ export default {
       if (this.balls.length === 0) {
         // 終了処理(パーフェクトの場合＋3000)
         this.score += 3000;
-        this.message = this.$gameMessage.perfect + "（+3000）";
+        this.message = this.$gameMessage.perfect + "（＋3000）";
         this.endOfGame();
         return
       }

--- a/components/rankings/Ranking.vue
+++ b/components/rankings/Ranking.vue
@@ -57,10 +57,10 @@
                     <i class="mdi mdi-crown-outline"></i>
                     {{ index + 1 }}
                   </td>
-                  <td :class="breakpointClass.header" class="text-left ranking-name">{{ ranking.name }}</td>
+                  <td :class="breakpointClass.header" class="text-left ranking-name">{{ getUserName(ranking) }}</td>
                   <td :class="breakpointClass.header" class="text-left">{{ ranking.score === 0 ? "-" : ranking.score }}</td>
                   <td :class="breakpointClass.header" class="text-left">{{ ranking.clearTime | zeroPadAndFormat }}</td>
-                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="'https://twitter.com/' + ranking.twitterId" icon class="ranking-twitter-btn"><v-icon>mdi-twitter</v-icon></v-btn></td>
+                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="getHref(ranking)" icon class="ranking-twitter-btn"><v-icon>{{ getIcon(ranking) }}</v-icon></v-btn></td>
                 </tr>
                 <!-- 2位 -->
                 <tr
@@ -72,10 +72,10 @@
                     <i class="mdi mdi-chess-king"></i>
                     {{ index + 2 }}
                   </td>
-                  <td :class="breakpointClass.header" class="text-left ranking-name">{{ ranking.name }}</td>
+                  <td :class="breakpointClass.header" class="text-left ranking-name">{{ getUserName(ranking) }}</td>
                   <td :class="breakpointClass.header" class="text-left">{{ ranking.score === 0 ? "-" : ranking.score }}</td>
                   <td :class="breakpointClass.header" class="text-left">{{ ranking.clearTime | zeroPadAndFormat }}</td>
-                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="'https://twitter.com/' + ranking.twitterId" icon class="ranking-twitter-btn"><v-icon>mdi-twitter</v-icon></v-btn></td>
+                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="getHref(ranking)" icon class="ranking-twitter-btn"><v-icon>{{ getIcon(ranking) }}</v-icon></v-btn></td>
                 </tr>
                 <!-- 3位 -->
                 <tr
@@ -87,10 +87,10 @@
                     <i class="mdi mdi-diamond-stone"></i>
                     {{ index + 3 }}
                   </td>
-                  <td :class="breakpointClass.header" class="text-left ranking-name">{{ ranking.name }}</td>
+                  <td :class="breakpointClass.header" class="text-left ranking-name">{{ getUserName(ranking) }}</td>
                   <td :class="breakpointClass.header" class="text-left">{{ ranking.score === 0 ? "-" : ranking.score }}</td>
                   <td :class="breakpointClass.header" class="text-left">{{ ranking.clearTime | zeroPadAndFormat }}</td>
-                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="'https://twitter.com/' + ranking.twitterId" icon class="ranking-twitter-btn"><v-icon>mdi-twitter</v-icon></v-btn></td>
+                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="getHref(ranking)" icon class="ranking-twitter-btn"><v-icon>{{ getIcon(ranking) }}</v-icon></v-btn></td>
                 </tr>
                 <!-- 4位以下 -->
                 <tr
@@ -99,10 +99,10 @@
                   class="ranking-tr"
                 >
                   <td :class="breakpointClass.header" class="text-center">{{ index + 4 }}</td>
-                  <td :class="breakpointClass.header" class="text-left ranking-name">{{ ranking.name }}</td>
+                  <td :class="breakpointClass.header" class="text-left ranking-name">{{ getUserName(ranking) }}</td>
                   <td :class="breakpointClass.header" class="text-left">{{ ranking.score === 0 ? "-" : ranking.score }}</td>
                   <td :class="breakpointClass.header" class="text-left">{{ ranking.clearTime | zeroPadAndFormat }}</td>
-                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="'https://twitter.com/' + ranking.twitterId" icon class="ranking-twitter-btn"><v-icon>mdi-twitter</v-icon></v-btn></td>
+                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="getHref(ranking)" icon class="ranking-twitter-btn"><v-icon>{{ getIcon(ranking) }}</v-icon></v-btn></td>
                 </tr>
               </template>
               <template v-else>
@@ -112,11 +112,11 @@
                   :key="index"
                 >
                   <td :class="breakpointClass.header" class="text-center">{{ index + 1 }}</td>
-                  <td :class="breakpointClass.header" class="text-left battle-name">{{ battle.name }}</td>
+                  <td :class="breakpointClass.header" class="text-left battle-name">{{ getUserName(battle) }}</td>
                   <td :class="breakpointClass.header" class="text-center">{{ battle.win }}</td>
                   <td :class="breakpointClass.header" class="text-center">{{ battle.lose }}</td>
                   <td :class="breakpointClass.header" class="text-center">{{ battle.draw }}</td>
-                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="'https://twitter.com/' + battle.id" icon class="battle-twitter-btn"><v-icon>mdi-twitter</v-icon></v-btn></td>
+                  <td :class="breakpointClass.header" class="text-center"><v-btn :href="getHref(battle)" icon class="battle-twitter-btn"><v-icon>{{ getIcon(battle) }}</v-icon></v-btn></td>
                 </tr>
               </template> 
             </tbody>
@@ -166,6 +166,40 @@ export default {
           rankingValue: "ranking-value"
         }
       }
+    },
+    getUserName(value) {
+      // ユーザ情報のプライバシーチェックをし、trueであればUser名を隠す
+      if (typeof value.user.privacy !== "undefined") {
+        if (value.user.privacy) {
+          // プライベートモード時はnameを返さない
+          return this.$user.secretUserName;
+        } else {
+          return value.name;
+        }
+      }
+    },
+    getHref(value) {
+      // ユーザ情報のプライバシーチェックをし、trueであればTwitterUrlを隠す
+      if (typeof value.user.privacy !== "undefined") {
+        if (value.user.privacy) {
+          // プライベートモード時はtwitter urlを返さない
+          return "";
+        } else {
+          return 'https://twitter.com/' + value.twitterId;
+        }
+      }
+    },
+    getIcon(value) {
+      // ユーザ情報のプライバシーチェックをし、trueであればTwitterアイコンを隠す
+      if (typeof value.user.privacy !== "undefined") {
+        if (value.user.privacy) {
+          // プライベートモード時はtwitterIconを返さない
+          return "mdi-help";
+        } else {
+          return "mdi-twitter";
+        }
+      }
+      // help
     }
   },
   computed: {

--- a/plugins/blackpink-config.js
+++ b/plugins/blackpink-config.js
@@ -21,6 +21,7 @@ Vue.prototype.$testInfo = {
 Vue.prototype.$user = {
   defaultName: "NO NAME",
   defaultRankId: "new",
+  secretUserName: "???",
 }
 
 Vue.prototype.$mode = {

--- a/store/battles.js
+++ b/store/battles.js
@@ -16,28 +16,37 @@ const actions = {
   init: firestoreAction(({ bindFirestoreRef }) => {
     bindFirestoreRef('battles', battlesRef)
   }),
-  winUpdate: firestoreAction((context, payload) => {
+  winUpdate: firestoreAction(async (context, payload) => {
+    // ユーザ情報をreferenceとして保持
+    const userDocSnapshot = await firebase.auth().currentUser !== null ? db.collection('users').doc(firebase.auth().currentUser.uid) : "";
     const id = getCurrentUserId(payload.twitterId, firebase.auth().currentUser);
     // set merge trueでなければ登録あれば追加
     battlesRef.doc(id).set({
       name: payload.name,
       win: firebase.firestore.FieldValue.increment(1),
+      user: userDocSnapshot,
     }, { merge: true });
   }),
-  loseUpdate: firestoreAction((context, payload) => {
+  loseUpdate: firestoreAction(async (context, payload) => {
+    // ユーザ情報をreferenceとして保持
+    const userDocSnapshot = await firebase.auth().currentUser !== null ? db.collection('users').doc(firebase.auth().currentUser.uid) : "";
     const id = getCurrentUserId(payload.twitterId, firebase.auth().currentUser);
     // set merge trueでなければ登録あれば追加
     battlesRef.doc(id).update({
       name: payload.name,
       lose: firebase.firestore.FieldValue.increment(1),
+      user: userDocSnapshot,
     }, { merge: true });
   }),
-  drawUpdate: firestoreAction((context, payload) => {
+  drawUpdate: firestoreAction(async (context, payload) => {
+    // ユーザ情報をreferenceとして保持
+    const userDocSnapshot = await firebase.auth().currentUser !== null ? db.collection('users').doc(firebase.auth().currentUser.uid) : "";
     const id = getCurrentUserId(payload.twitterId, firebase.auth().currentUser);
     // set merge trueでなければ登録あれば追加
     battlesRef.doc(id).update({
       name: payload.name,
       draw: firebase.firestore.FieldValue.increment(1),
+      user: userDocSnapshot,
     });
   }, { merge: true }),
 }
@@ -51,6 +60,11 @@ export default {
   getters,
   mutations,
   actions,
+}
+
+// ユーザ情報取得
+function getUser() {
+
 }
 
 // 自分のユーザIDを取得

--- a/store/battles.js
+++ b/store/battles.js
@@ -19,33 +19,36 @@ const actions = {
   winUpdate: firestoreAction(async (context, payload) => {
     // ユーザ情報をreferenceとして保持
     const userDocSnapshot = await firebase.auth().currentUser !== null ? db.collection('users').doc(firebase.auth().currentUser.uid) : "";
-    const id = getCurrentUserId(payload.twitterId, firebase.auth().currentUser);
+    const id = getCurrentUserId(firebase.auth().currentUser);
     // set merge trueでなければ登録あれば追加
     battlesRef.doc(id).set({
       name: payload.name,
       win: firebase.firestore.FieldValue.increment(1),
+      twitterId: payload.twitterId,
       user: userDocSnapshot,
     }, { merge: true });
   }),
   loseUpdate: firestoreAction(async (context, payload) => {
     // ユーザ情報をreferenceとして保持
     const userDocSnapshot = await firebase.auth().currentUser !== null ? db.collection('users').doc(firebase.auth().currentUser.uid) : "";
-    const id = getCurrentUserId(payload.twitterId, firebase.auth().currentUser);
+    const id = getCurrentUserId(firebase.auth().currentUser);
     // set merge trueでなければ登録あれば追加
     battlesRef.doc(id).update({
       name: payload.name,
       lose: firebase.firestore.FieldValue.increment(1),
+      twitterId: payload.twitterId,
       user: userDocSnapshot,
     }, { merge: true });
   }),
   drawUpdate: firestoreAction(async (context, payload) => {
     // ユーザ情報をreferenceとして保持
     const userDocSnapshot = await firebase.auth().currentUser !== null ? db.collection('users').doc(firebase.auth().currentUser.uid) : "";
-    const id = getCurrentUserId(payload.twitterId, firebase.auth().currentUser);
+    const id = getCurrentUserId(firebase.auth().currentUser);
     // set merge trueでなければ登録あれば追加
     battlesRef.doc(id).update({
       name: payload.name,
       draw: firebase.firestore.FieldValue.increment(1),
+      twitterId: payload.twitterId,
       user: userDocSnapshot,
     });
   }, { merge: true }),
@@ -68,7 +71,7 @@ function getUser() {
 }
 
 // 自分のユーザIDを取得
-function getCurrentUserId(twitterId, currentUser) {
+function getCurrentUserId(currentUser) {
   if (currentUser !== null) {
     // 認証済みの場合
     return currentUser.uid;

--- a/store/battles.js
+++ b/store/battles.js
@@ -53,6 +53,7 @@ export default {
   actions,
 }
 
+// 自分のユーザIDを取得
 function getCurrentUserId(twitterId, currentUser) {
   if (currentUser !== null) {
     // 認証済みの場合

--- a/store/rankings.js
+++ b/store/rankings.js
@@ -26,7 +26,9 @@ const actions = {
   init: firestoreAction(({ bindFirestoreRef }) => {
     bindFirestoreRef('rankings', rankingsRef)
   }),
-  add: firestoreAction((context, ranking) => {
+  add: firestoreAction(async (context, ranking) => {
+    // 自身のユーザ情報とランキング情報を紐づける(reference)
+    const userDocSnapshot = await db.collection('users').doc(firebase.auth().currentUser.uid);
     // ランキングをFirestoreへ登録
     rankingsRef.add({
       name: ranking.name,
@@ -34,7 +36,8 @@ const actions = {
       score: ranking.score,
       clearTime: ranking.clearTime,
       modeType: ranking.modeType,
-      createdAt: firebase.firestore.FieldValue.serverTimestamp()
+      createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+      user: userDocSnapshot,
     })
   }),
 };


### PR DESCRIPTION
- rankingsコレクションとbattlesコレクションのフィールドにreference型のuser情報を追加

[![Image from Gyazo](https://i.gyazo.com/ceed65ec238cbb19a977e4c3f253831a.png)](https://gyazo.com/ceed65ec238cbb19a977e4c3f253831a)

- Ranking画面表示時、追加したreference型のユーザ情報のプライバシー情報で判断しtrueの場合ユーザのTwitter情報を隠すよう修正

[![Image from Gyazo](https://i.gyazo.com/d8ee33e2a02c65300f83853e050a0377.png)](https://gyazo.com/d8ee33e2a02c65300f83853e050a0377)