### PR TITLE
blinksページにカーソルポインター付与css(#219)

### DIFF
--- a/pages/blinks/index.vue
+++ b/pages/blinks/index.vue
@@ -82,6 +82,7 @@ export default {
 .blink {
   margin: 2% 4%;
   text-align: left;
+  cursor: pointer;
 }
 
 .user-common {


### PR DESCRIPTION
以下のユーザ一覧に詳細が見えることを示すカーソルポインター付与（css）

[![Image from Gyazo](https://i.gyazo.com/35a2050ab51061b90c0dbafa10414d0d.png)](https://gyazo.com/35a2050ab51061b90c0dbafa10414d0d)