### PR TITLE
勝敗引の表示バグ解消（#222）

### DIFF
--- a/pages/blinks/_blink.vue
+++ b/pages/blinks/_blink.vue
@@ -342,6 +342,7 @@ export default {
   },
   created() {
     this.$store.dispatch('users/init');
+    this.$store.dispatch('battles/init');
     this.$store.dispatch('rankings/init');
 
     // 選択したユーザ取得
@@ -349,6 +350,7 @@ export default {
     const _this = this;
     docUser.get().then(function(doc) {
       _this.showUser = doc.data();
+      _this.showUser.uid = doc.ref.id;
     });
   },
   components: {


### PR DESCRIPTION
ユーザ詳細ページでbattleコレクションを初期化することで対応

```
this.$store.dispatch('battles/init');
```