### PR TITLE
Feature/send to slack #205

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ serviceAccount.json
 # firebase関連（firestoreルール）
 .firebase/
 firestore.rules
+
+/functions/.runtimeconfig.json

--- a/firebase.json
+++ b/firebase.json
@@ -28,6 +28,9 @@
     },
     "pubsub": {
       "port": 8085
+    },
+    "auth": {
+      "port": 9099
     }
   },
   "firestore": {

--- a/functions/index.js
+++ b/functions/index.js
@@ -9,6 +9,7 @@ const waitingsRef = db.collection('waitings');
 const roomsRef = db.collection('rooms');
 const youtubesRef = db.collection('youtubes');
 
+// functions:config:set slack_service.adminurlにスラックのURLを設定
 const { IncomingWebhook } = require('@slack/webhook');
 
 // // Create and Deploy Your First Cloud Functions
@@ -225,10 +226,31 @@ exports.addReferenceUserField = functions.region('asia-northeast1').https.onRequ
 });
 
 // ユーザ登録時、スラック通知
-exports.sendToSlack = functions.auth.user().onCreate(async (user) => {
-  console.log("fewfwefewfwfef");
-  await sendWebhookSlack.send({
-    text: '新たにユーザ登録:' + user
+exports.sendToSlack = functions.region('asia-northeast1').auth.user().onCreate(async (user) => {
+  console.log('ユーザ登録時のスラック通知開始');
+  const webhook = new IncomingWebhook(functions.config().slack_service.adminurl);
+
+  // 送信する文字列作成
+  const textArray = [
+    `ユーザ登録通知`,
+    `ユーザ名「${user.displayName}」さんがユーザ登録しました。`
+  ];
+
+  // slackAPIが受け取れるオブジェクト生成
+  const data = {
+    text: textArray.join('\n'),
+    username: 'Blink Games BOT',
+    icon_emoji: ':ghost:'
+  }
+
+  // slack通知
+  await webhook.send(data)
+  .then(() => {
+    console.log("ユーザ登録のSlack通知に成功");
+  }).catch(error => {
+    console.info(new Error('ユーザ登録の通知に失敗')); // Logging an Error object at the info level
+    console.error('ユーザ登録のスラック通知に失敗しました'); 
   });
+
   return null;
 });

--- a/functions/index.js
+++ b/functions/index.js
@@ -9,6 +9,8 @@ const waitingsRef = db.collection('waitings');
 const roomsRef = db.collection('rooms');
 const youtubesRef = db.collection('youtubes');
 
+const { IncomingWebhook } = require('@slack/webhook');
+
 // // Create and Deploy Your First Cloud Functions
 // // https://firebase.google.com/docs/functions/write-firebase-functions
 //
@@ -220,4 +222,13 @@ exports.addReferenceUserField = functions.region('asia-northeast1').https.onRequ
       batch.commit();
     }
   });
+});
+
+// ユーザ登録時、スラック通知
+exports.sendToSlack = functions.auth.user().onCreate(async (user) => {
+  console.log("fewfwefewfwfef");
+  await sendWebhookSlack.send({
+    text: '新たにユーザ登録:' + user
+  });
+  return null;
 });

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@slack/webhook": "^6.0.0",
         "firebase-admin": "^9.2.0",
         "firebase-functions": "^3.11.0"
       },
@@ -274,6 +275,29 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
       "optional": true
     },
+    "node_modules/@slack/types": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.10.0.tgz",
+      "integrity": "sha512-tA7GG7Tj479vojfV3AoxbckalA48aK6giGjNtgH6ihpLwTyHE3fIgRrvt8TWfLwW8X8dyu7vgmAsGLRG7hWWOg==",
+      "engines": {
+        "node": ">= 8.9.0",
+        "npm": ">= 5.5.1"
+      }
+    },
+    "node_modules/@slack/webhook": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-6.0.0.tgz",
+      "integrity": "sha512-2fohfhLI9lkAmOSWt1R457JBsB3iFNqahu4GqdFZRtcp/bT+xeG/kPn/hQa78JS74poRjWTt5G/qJjNaWMGOEQ==",
+      "dependencies": {
+        "@slack/types": "^1.2.1",
+        "@types/node": ">=12.0.0",
+        "axios": "^0.21.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0",
+        "npm": ">= 6.12.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -482,6 +506,14 @@
       "optional": true,
       "dependencies": {
         "retry": "0.12.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
       }
     },
     "node_modules/base64-js": {
@@ -931,6 +963,25 @@
       "peerDependencies": {
         "firebase-admin": ">=6.0.0",
         "firebase-functions": ">=2.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/forwarded": {
@@ -2490,6 +2541,21 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
       "optional": true
     },
+    "@slack/types": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.10.0.tgz",
+      "integrity": "sha512-tA7GG7Tj479vojfV3AoxbckalA48aK6giGjNtgH6ihpLwTyHE3fIgRrvt8TWfLwW8X8dyu7vgmAsGLRG7hWWOg=="
+    },
+    "@slack/webhook": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-6.0.0.tgz",
+      "integrity": "sha512-2fohfhLI9lkAmOSWt1R457JBsB3iFNqahu4GqdFZRtcp/bT+xeG/kPn/hQa78JS74poRjWTt5G/qJjNaWMGOEQ==",
+      "requires": {
+        "@slack/types": "^1.2.1",
+        "@types/node": ">=12.0.0",
+        "axios": "^0.21.1"
+      }
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2668,6 +2734,14 @@
       "optional": true,
       "requires": {
         "retry": "0.12.0"
+      }
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
       }
     },
     "base64-js": {
@@ -3023,6 +3097,11 @@
         "@types/lodash": "^4.14.104",
         "lodash": "^4.17.5"
       }
+    },
+    "follow-redirects": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "forwarded": {
       "version": "0.1.2",

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,6 +13,7 @@
   },
   "main": "index.js",
   "dependencies": {
+    "@slack/webhook": "^6.0.0",
     "firebase-admin": "^9.2.0",
     "firebase-functions": "^3.11.0"
   },


### PR DESCRIPTION
ユーザ登録をトリガーとし、cloud functionsからスラックへユーザ登録の通知機能を実装
- エミュレータで確認済
- `firebase functions:config:set slack_service.adminurl=""`に設定済
- エミュレータにも反映済
`$ cd functions`
`$ firebase functions:config:get > .runtimeconfig.json`

サンプル 通知
curl -X POST -H 'Content-type: application/json' --data '{"text":"Hello, World!"}' https://hooks.slack.com/services/xxxxxxxxx/xxxxxxxx

通知例
[![Image from Gyazo](https://i.gyazo.com/e47f3c55d555b02eefcb0ba53c632eb7.png)](https://gyazo.com/e47f3c55d555b02eefcb0ba53c632eb7)