### PR TITLE
Feature/add error handling #138

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -76,10 +76,11 @@ export default {
   // 呼び出し側はapi以下の/v1/jp/itunes-music/hot-tracks/all/10/explicit.jsonを指定
   axios: {
     proxy: true,
-    prefix: '/search'
+    prefix: '/api'
   },
   proxy: {
-    '/search/': { target: process.env.ITUNES_APPLE_URL, }
+    '/search/': { target: process.env.ITUNES_APPLE_URL, },
+    '/services/': { target: process.env.SLACK_ERROR_URL },
   },
 
   // Vuetify module configuration: https://go.nuxtjs.dev/config-vuetify

--- a/store/battles.js
+++ b/store/battles.js
@@ -26,7 +26,21 @@ const actions = {
       win: firebase.firestore.FieldValue.increment(1),
       twitterId: payload.twitterId,
       user: userDocSnapshot,
-    }, { merge: true });
+    }, { merge: true })
+    .catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: battles/winUpdate`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
+    });
   }),
   loseUpdate: firestoreAction(async (context, payload) => {
     // ユーザ情報をreferenceとして保持
@@ -38,7 +52,21 @@ const actions = {
       lose: firebase.firestore.FieldValue.increment(1),
       twitterId: payload.twitterId,
       user: userDocSnapshot,
-    }, { merge: true });
+    }, { merge: true })
+    .catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: battles/loseUpdate`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
+    });
   }),
   drawUpdate: firestoreAction(async (context, payload) => {
     // ユーザ情報をreferenceとして保持
@@ -50,6 +78,19 @@ const actions = {
       draw: firebase.firestore.FieldValue.increment(1),
       twitterId: payload.twitterId,
       user: userDocSnapshot,
+    }).catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: battles/drawUpdate`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
     });
   }, { merge: true }),
 }

--- a/store/errors.js
+++ b/store/errors.js
@@ -1,0 +1,20 @@
+import axios from 'axios';
+
+const actions = {
+  sendSlackOfError(context, payload) {
+    // エラー情報をスラックに通知
+    // slack APIが受け取れるオブジェクトを生成
+    const data = {
+      text: payload.arrayMessage.join('\n'),
+      username: 'Blink Games BOT',
+      icon_emoji: ':ghost:',
+    };
+
+    // axiosでslack通知
+    axios.post('/services' + process.env.SLACK_ERROR_PATH, data);
+  },
+};
+
+export default {
+  actions,
+}

--- a/store/rankings.js
+++ b/store/rankings.js
@@ -38,6 +38,19 @@ const actions = {
       modeType: ranking.modeType,
       createdAt: firebase.firestore.FieldValue.serverTimestamp(),
       user: userDocSnapshot,
+    }).catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: rankings/add`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
     })
   }),
 };

--- a/store/rooms.js
+++ b/store/rooms.js
@@ -54,7 +54,21 @@ const actions = {
       userIds: [payload.twitterId, "account"],
       version: 0,
       createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-    }, { merge: false });
+    }, { merge: false })
+    .catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: rooms/createCom`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
+    });
   }),
 }
 

--- a/store/twitter.js
+++ b/store/twitter.js
@@ -27,8 +27,19 @@ const actions = {
 
         // 第二引数のコールバック関数呼び出し（認証したユーザ情報を元に、スナックバー通知とステータス登録）
         afterAuthenticationFunc();
-      }).catch(function (error) {
-        console.log(error)
+      }).catch(error => {
+        // エラー情報を生成
+        const arrayMessage = [
+          `error location: twitter/loginTwitter`,
+          `errorCode: ${error.code}`,
+          `errorMessage: ${error.message}`,
+        ];
+  
+        // スラック通知呼び出し
+        context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+  
+        // 500エラー
+        $nuxt.error({statusCode: 500});
       })
   },
   logoutTwitter(context, afterAuthenticationFunc) {
@@ -36,8 +47,19 @@ const actions = {
       .then(()=> {
         context.dispatch('localStorages/initializationLocalStorage', '', { root: true }); // twitterアクションからlocalStoragesアクションを呼ぶ
       })
-      .catch((error) => {
-        console.log(error);
+      .catch(error => {
+        // エラー情報を生成
+        const arrayMessage = [
+          `error location: twitter/logoutTwitter`,
+          `errorCode: ${error.code}`,
+          `errorMessage: ${error.message}`,
+        ];
+  
+        // スラック通知呼び出し
+        context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+  
+        // 500エラー
+        $nuxt.error({statusCode: 500});
       })
   },
   updateTwitter(context) {

--- a/store/users.js
+++ b/store/users.js
@@ -1,5 +1,6 @@
 import firebase, { db } from "~/plugins/firebase";
 import { firestoreAction } from 'vuexfire';
+import axios from 'axios';
 
 const usersRef = db.collection('users');
 
@@ -88,7 +89,27 @@ const actions = {
       else {
         // ドキュメントが取得できなかった場合
       }
-    })
+    }).catch(error => {
+      // エラー情報をスラックに通知
+      const arrayMessage = [
+        `error location: users/get`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // slack APIが受け取れるオブジェクトを生成
+      const data = {
+        text: arrayMessage.join('\n'),
+        username: 'Blink Games BOT',
+        icon_emoji: ':ghost:',
+      };
+
+      // axiosでslack通知
+      axios.post('/services' + process.env.SLACK_ERROR_PATH, data);
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
+    });
   }),
   setUser(context, userObject) {
     // storeのuserにユーザ情報保持

--- a/store/users.js
+++ b/store/users.js
@@ -55,6 +55,19 @@ const actions = {
       }
 
       context.dispatch('setUser', userObject);
+    }).catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: users/set`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
     })
   }),
   update: firestoreAction((context, userObject) => {
@@ -65,6 +78,19 @@ const actions = {
       photoURL: userObject.photoURL,
       privacy: userObject.privacy,
       createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+    }).catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: users/update`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
     });
 
     context.dispatch('setUser', userObject);
@@ -73,6 +99,19 @@ const actions = {
     usersRef.doc(userObject.id).update({
       name: userObject.name,
       photoURL: userObject.photoURL,
+    }).catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: users/updateTwitter`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
     });
 
     context.commit('updateTwitterInfo', userObject);

--- a/store/users.js
+++ b/store/users.js
@@ -1,6 +1,5 @@
 import firebase, { db } from "~/plugins/firebase";
 import { firestoreAction } from 'vuexfire';
-import axios from 'axios';
 
 const usersRef = db.collection('users');
 
@@ -90,22 +89,15 @@ const actions = {
         // ドキュメントが取得できなかった場合
       }
     }).catch(error => {
-      // エラー情報をスラックに通知
+      // エラー情報を生成
       const arrayMessage = [
         `error location: users/get`,
         `errorCode: ${error.code}`,
         `errorMessage: ${error.message}`,
       ];
 
-      // slack APIが受け取れるオブジェクトを生成
-      const data = {
-        text: arrayMessage.join('\n'),
-        username: 'Blink Games BOT',
-        icon_emoji: ':ghost:',
-      };
-
-      // axiosでslack通知
-      axios.post('/services' + process.env.SLACK_ERROR_PATH, data);
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
 
       // 500エラー
       $nuxt.error({statusCode: 500});

--- a/store/waitings.js
+++ b/store/waitings.js
@@ -22,7 +22,21 @@ const actions = {
       roomId: "",
       status: 0,
       updateAt: firebase.firestore.FieldValue.serverTimestamp(),
-    }, { merge: false });
+    }, { merge: false })
+    .catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: waitings/set`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
+    });
   }),
   setCom: firestoreAction((context, uid) => {
     // マッチ済みに登録しCOMと対戦
@@ -31,6 +45,20 @@ const actions = {
       status: 1,
       updateAt: firebase.firestore.FieldValue.serverTimestamp(),
     }, { merge: false })
+    .catch(error => {
+      // エラー情報を生成
+      const arrayMessage = [
+        `error location: waitings/setCom`,
+        `errorCode: ${error.code}`,
+        `errorMessage: ${error.message}`,
+      ];
+
+      // スラック通知呼び出し
+      context.dispatch('errors/sendSlackOfError', { arrayMessage: arrayMessage }, { root: true });
+
+      // 500エラー
+      $nuxt.error({statusCode: 500});
+    })
   }),
 }
 


### PR DESCRIPTION
errors.jsを追加しそこで共通処理として、エラーをcatchしエラー情報をスラックへ通知するよう実装

```
const actions = {
  sendSlackOfError(context, payload) {
    // エラー情報をスラックに通知
    // slack APIが受け取れるオブジェクトを生成
    const data = {
      text: payload.arrayMessage.join('\n'),
      username: 'Blink Games BOT',
      icon_emoji: ':ghost:',
    };

    // axiosでslack通知
    axios.post('/services' + process.env.SLACK_ERROR_PATH, data);
  },
};
```